### PR TITLE
add register parameter function

### DIFF
--- a/HttpClientMock.Tests/CreateArticleTests.cs
+++ b/HttpClientMock.Tests/CreateArticleTests.cs
@@ -17,7 +17,8 @@ namespace HttpClientMock.Tests
   ""description"": ""THE DESCRIPTION"",
   ""id"": 101
 }";
-            var messageHandler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+            var messageHandler = new MockHttpMessageHandler();
+            MockHttpMessageHandler.RegisterResponse(HttpStatusCode.OK, response);
             var httpClient = new HttpClient(messageHandler)
             {
                 BaseAddress = new Uri("http://not-important.com")
@@ -40,12 +41,15 @@ namespace HttpClientMock.Tests
         public async Task GivenErrorResponseFromServer_WhenArticlePosted_ThenErrorMessageIsReturned()
         {
             var response = string.Empty;
-            var messageHandler = new MockHttpMessageHandler(response, HttpStatusCode.InternalServerError);
+            var messageHandler = new MockHttpMessageHandler();
+
             var httpClient = new HttpClient(messageHandler)
             {
                 BaseAddress = new Uri("http://not-important.com")
             };
             var sut = new BlogClient(httpClient);
+
+            MockHttpMessageHandler.RegisterResponse(HttpStatusCode.InternalServerError, response);
 
             var result = await sut.CreateArticle(new Article
             {

--- a/HttpClientMock.Tests/DoubleRegisterTests.cs
+++ b/HttpClientMock.Tests/DoubleRegisterTests.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HttpClientMock.Tests
+{
+    public class DoubleRegisterTests
+    {
+        [Fact]
+        public async Task Test_Double_Register_Returned_In_Right_Order()
+        {
+            HttpClient client = new HttpClient(new MockHttpMessageHandler());
+
+            MockHttpMessageHandler.RegisterResponse(HttpStatusCode.Accepted, "abc");
+            MockHttpMessageHandler.RegisterResponse(HttpStatusCode.BadRequest, "def");
+
+            var first = await client.GetAsync("https://www.google.com");
+            var firstStr = await first.Content.ReadAsStringAsync();
+
+            var second = await client.GetAsync("https://www.google.com");
+            var secondStr = await second.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.Accepted, first.StatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, second.StatusCode);
+
+            Assert.Equal("abc", firstStr);
+            Assert.Equal("def", secondStr);
+
+
+
+
+        }
+    }
+}

--- a/HttpClientMock.Tests/GetAllArticlesTests.cs
+++ b/HttpClientMock.Tests/GetAllArticlesTests.cs
@@ -27,7 +27,8 @@ namespace HttpClientMock.Tests
   ""description"": ""THE DESCRIPTION"",
   ""id"": 3
 }]";
-            var messageHandler = new MockHttpMessageHandler(response, HttpStatusCode.OK);
+            var messageHandler = new MockHttpMessageHandler();
+            MockHttpMessageHandler.RegisterResponse(HttpStatusCode.OK, response);
             var httpClient = new HttpClient(messageHandler)
             {
                 BaseAddress = new Uri("http://not-important.com")

--- a/HttpClientMock.Tests/MockHttpMessageHandler.cs
+++ b/HttpClientMock.Tests/MockHttpMessageHandler.cs
@@ -7,33 +7,40 @@ namespace HttpClientMock.Tests
 {
     public class MockHttpMessageHandler : HttpMessageHandler
     {
-        private readonly string _response;
-        private readonly HttpStatusCode _statusCode;
-
         public string Input { get; private set; }
         public int NumberOfCalls { get; private set; }
 
-        public MockHttpMessageHandler(string response, HttpStatusCode statusCode)
+        public MockHttpMessageHandler()
         {
-            _response = response;
-            _statusCode = statusCode;
+        }
+
+        private static (HttpStatusCode statusCode, string response) nextResponse;
+
+        public static void RegisterResponse(HttpStatusCode statusCode, string response)
+        {
+            nextResponse.response = response;
+            nextResponse.statusCode = statusCode;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             NumberOfCalls++;
-            
-            if (request.Content != null)
+            if (request.Content != null) // Could be a GET-request without a body
             {
                 Input = await request.Content.ReadAsStringAsync();
             }
-            
-            return new HttpResponseMessage
+
+            var res = new HttpResponseMessage
             {
-                StatusCode = _statusCode,
-                Content = new StringContent(_response)
+                StatusCode = nextResponse.statusCode,
+                Content = new StringContent(nextResponse.response)
             };
+
+            nextResponse.statusCode = default(HttpStatusCode);
+            nextResponse.response = null;
+
+            return res;
         }
     }
 }


### PR DESCRIPTION
Hi,

I propose to add a register function.
The reason in you don't know always when you create the `httpclient`, 
what will be the parameter you will want to send.

Furthermore, with a register function you can perform multiple register and be able to test your code even if there is more than one HTTP request in your code.  